### PR TITLE
Includes models for DH, SHA, FFC, and MD5

### DIFF
--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -53,6 +53,7 @@ struct dh_method {
     char *name;
 };
 
+bool openssl_DH_is_valid(const DH *dh);
 void DH_free(DH *dh);
 int DH_size(const DH *dh);
 DH *d2i_DHparams(DH **a, unsigned char **pp, long length);

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -24,14 +24,6 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
-#ifndef OPENSSL_DH_H
-#    define OPENSSL_DH_H
-#    pragma once
-
-#    ifndef OPENSSL_NO_DEPRECATED_3_0
-#        define HEADER_DH_H
-#    endif
-
 /*
  * The structs dh_st and dh_method have been cut down to contain
  * only the parts relevant to the s2n_pkcs3_to_dh_params proof.
@@ -64,5 +56,3 @@ struct dh_method {
 void DH_free(DH *dh);
 int DH_size(const DH *dh);
 DH *d2i_DHparams(DH **a, unsigned char **pp, long length);
-
-#endif

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -1,0 +1,68 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+#include <openssl/bn.h>
+#include <openssl/ffc.h>
+#include <stdint.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#ifndef OPENSSL_DH_H
+#    define OPENSSL_DH_H
+#    pragma once
+
+#    ifndef OPENSSL_NO_DEPRECATED_3_0
+#        define HEADER_DH_H
+#    endif
+
+/*
+ * The structs dh_st and dh_method have been cut down to contain
+ * only the parts relevant to the s2n_pkcs3_to_dh_params proof.
+ */
+
+struct dh_st {
+    /*
+     * This first argument is used to pick up errors when a DH is passed
+     * instead of a EVP_PKEY
+     */
+    int pad;
+    int version;
+    FFC_PARAMS params;
+    /* max generated private key length (can be less than len(q)) */
+    int32_t length;
+    BIGNUM *pub_key;  /* g^x % p */
+    BIGNUM *priv_key; /* x */
+    int flags;
+    BIGNUM *p;
+    BIGNUM *g;
+
+    /* Provider data */
+    size_t dirty_cnt; /* If any key material changes, increment this */
+};
+
+struct dh_method {
+    char *name;
+};
+
+void DH_free(DH *dh);
+int DH_size(const DH *dh);
+DH *d2i_DHparams(DH **a, unsigned char **pp, long length);
+
+#endif

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -22,8 +22,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define EVP_MAX_MD_SIZE 64  /* longest known is SHA512 */
-#define EVP_PKEY_HKDF 1036  // reference from obj_mac.h
+#define EVP_MAX_MD_SIZE 64                    /* Longest known is SHA512. */
+#define EVP_PKEY_HKDF 1036                    /* Reference from obj_mac.h. */
+#define EVP_MD_CTX_FLAG_NON_FIPS_ALLOW 0x0008 /* Allow use of non FIPS digest in FIPS mode. */
 
 enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM };
 enum evp_sha { EVP_SHA256, EVP_SHA384, EVP_SHA512 };

--- a/include/openssl/ffc.h
+++ b/include/openssl/ffc.h
@@ -1,0 +1,48 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/bn.h>
+
+#ifndef OSSL_INTERNAL_FFC_H
+#    define OSSL_INTERNAL_FFC_H
+
+typedef struct ffc_params_st {
+    /* Primes */
+    BIGNUM *p;
+    BIGNUM *q;
+    /* Generator */
+    BIGNUM *g;
+    /* DH X9.42 Optional Subgroup factor j >= 2 where p = j * q + 1 */
+    BIGNUM *j;
+
+    /* Required for FIPS186_4 validation of p, q and optionally canonical g */
+    unsigned char *seed;
+    /* If this value is zero the hash size is used as the seed length */
+    size_t seedlen;
+    /* Required for FIPS186_4 validation of p and q */
+    int pcounter;
+    int nid; /* The identity of a named group */
+
+    /*
+     * Required for FIPS186_4 generation & validation of canonical g.
+     * It uses unverifiable g if this value is -1.
+     */
+    int gindex;
+    int h; /* loop counter for unverifiable g */
+} FFC_PARAMS;
+
+#endif

--- a/include/openssl/md5.h
+++ b/include/openssl/md5.h
@@ -1,0 +1,55 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_MD5_H
+#define HEADER_MD5_H
+
+/*
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * ! MD5_LONG has to be at least 32 bits wide. If it's wider, then !
+ * ! MD5_LONG_LOG2 has to be defined along.			   !
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ */
+
+#if defined(__LP32__)
+#    define MD5_LONG unsigned long
+#elif defined(OPENSSL_SYS_CRAY) || defined(__ILP64__)
+#    define MD5_LONG unsigned long
+#    define MD5_LONG_LOG2 3
+/*
+ * _CRAY note. I could declare short, but I have no idea what impact
+ * does it have on performance on none-T3E machines. I could declare
+ * int, but at least on C90 sizeof(int) can be chosen at compile time.
+ * So I've chosen long...
+ *					<appro@fy.chalmers.se>
+ */
+#else
+#    define MD5_LONG unsigned int
+#endif
+
+#define MD5_CBLOCK 64
+#define MD5_LBLOCK (MD5_CBLOCK / 4)
+#define MD5_DIGEST_LENGTH 16
+
+typedef struct MD5state_st {
+    MD5_LONG A, B, C, D;
+    MD5_LONG Nl, Nh;
+    MD5_LONG data[MD5_LBLOCK];
+    unsigned int num;
+} MD5_CTX;
+
+#endif

--- a/include/openssl/md5.h
+++ b/include/openssl/md5.h
@@ -46,7 +46,9 @@
 #define MD5_DIGEST_LENGTH 16
 
 typedef struct MD5state_st {
+    /* Internal buffers used during the computation. */
     MD5_LONG A, B, C, D;
+    /* The other subfields keep information on the running hash. */
     MD5_LONG Nl, Nh;
     MD5_LONG data[MD5_LBLOCK];
     unsigned int num;

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -1,0 +1,101 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_SHA_H
+#define HEADER_SHA_H
+
+/*
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * ! SHA_LONG has to be at least 32 bits wide. If it's wider, then !
+ * ! SHA_LONG_LOG2 has to be defined along.                        !
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ */
+
+#if defined(__LP32__)
+#    define SHA_LONG unsigned long
+#elif defined(OPENSSL_SYS_CRAY) || defined(__ILP64__)
+#    define SHA_LONG unsigned long
+#    define SHA_LONG_LOG2 3
+#else
+#    define SHA_LONG unsigned int
+#endif
+
+#define SHA_LBLOCK 16
+#define SHA_CBLOCK                                 \
+    (SHA_LBLOCK * 4) /* SHA treats input data as a \
+                      * contiguous array of 32 bit \
+                      * wide big-endian values. */
+#define SHA_LAST_BLOCK (SHA_CBLOCK - 8)
+#define SHA_DIGEST_LENGTH 20
+
+typedef struct SHAstate_st {
+    SHA_LONG h0, h1, h2, h3, h4;
+    SHA_LONG Nl, Nh;
+    SHA_LONG data[SHA_LBLOCK];
+    unsigned int num;
+} SHA_CTX;
+
+#define SHA256_CBLOCK                                  \
+    (SHA_LBLOCK * 4) /* SHA-256 treats input data as a \
+                      * contiguous array of 32 bit     \
+                      * wide big-endian values. */
+#define SHA224_DIGEST_LENGTH 28
+#define SHA256_DIGEST_LENGTH 32
+
+typedef struct SHA256state_st {
+    SHA_LONG h[8];
+    SHA_LONG Nl, Nh;
+    SHA_LONG data[SHA_LBLOCK];
+    unsigned int num, md_len;
+} SHA256_CTX;
+
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
+
+#ifndef OPENSSL_NO_SHA512
+/*
+ * Unlike 32-bit digest algorithms, SHA-512 *relies* on SHA_LONG64
+ * being exactly 64-bit wide. See Implementation Notes in sha512.c
+ * for further details.
+ */
+#    define SHA512_CBLOCK                                  \
+        (SHA_LBLOCK * 8) /* SHA-512 treats input data as a \
+                          * contiguous array of 64 bit     \
+                          * wide big-endian values. */
+#    if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+#        define SHA_LONG64 unsigned __int64
+#        define U64(C) C##UI64
+#    elif defined(__arch64__)
+#        define SHA_LONG64 unsigned long
+#        define U64(C) C##UL
+#    else
+#        define SHA_LONG64 unsigned long long
+#        define U64(C) C##ULL
+#    endif
+
+typedef struct SHA512state_st {
+    SHA_LONG64 h[8];
+    SHA_LONG64 Nl, Nh;
+    union {
+        SHA_LONG64 d[SHA_LBLOCK];
+        unsigned char p[SHA512_CBLOCK];
+    } u;
+    unsigned int num, md_len;
+} SHA512_CTX;
+#endif
+
+#endif

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -69,7 +69,7 @@ typedef struct SHA256state_st {
 #ifndef OPENSSL_NO_SHA512
 /*
  * Unlike 32-bit digest algorithms, SHA-512 *relies* on SHA_LONG64
- * being exactly 64-bit wide. See Implementation Notes in sha512.c
+ * being exactly 64-bit wide. See Implementation Notes in crypto/sha/sha512.c
  * for further details.
  */
 #    define SHA512_CBLOCK                                  \

--- a/source/dh_overrides.c
+++ b/source/dh_overrides.c
@@ -30,9 +30,11 @@ int DH_size(const DH *dh) {
 }
 
 void DH_free(DH *dh) {
+    assert(dh == NULL || openssl_DH_is_valid(dh));
     return;
 }
 
+/* Returns a dummy DH that can't be dereferenced. */
 DH *d2i_DHparams(DH **a, const unsigned char **pp, long length) {
     assert(**pp != NULL);
     DH *dummy_dh;

--- a/source/dh_overrides.c
+++ b/source/dh_overrides.c
@@ -20,6 +20,8 @@
 #include <openssl/ossl_typ.h>
 
 int DH_size(const DH *dh) {
+    assert(dh != NULL);
+    assert(dh->p != NULL);
     return nondet_int();
 }
 
@@ -28,6 +30,7 @@ void DH_free(DH *dh) {
 }
 
 DH *d2i_DHparams(DH **a, const unsigned char **pp, long length) {
+    assert(**pp != NULL);
     DH *dummy_dh;
     if (nondet_bool() && *pp != NULL) {
         *pp = *pp + length;

--- a/source/dh_overrides.c
+++ b/source/dh_overrides.c
@@ -1,0 +1,36 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+#include <openssl/dh.h>
+#include <openssl/ossl_typ.h>
+
+int DH_size(const DH *dh) {
+    return nondet_int();
+}
+
+void DH_free(DH *dh) {
+    return;
+}
+
+DH *d2i_DHparams(DH **a, const unsigned char **pp, long length) {
+    DH *dummy_dh;
+    if (nondet_bool() && *pp != NULL) {
+        *pp = *pp + length;
+    }
+    return dummy_dh;
+}

--- a/source/dh_overrides.c
+++ b/source/dh_overrides.c
@@ -19,8 +19,12 @@
 #include <openssl/dh.h>
 #include <openssl/ossl_typ.h>
 
+bool openssl_DH_is_valid(const DH *dh) {
+    return __CPROVER_w_ok(dh, sizeof(*dh));
+}
+
 int DH_size(const DH *dh) {
-    assert(dh != NULL);
+    assert(openssl_DH_is_valid(dh));
     assert(dh->p != NULL);
     return nondet_int();
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*

Includes all OpenSSL models used in `s2n`: DH, SHA, FFC, and MD5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
