### PR TITLE
Adds MD5 and SHA models with general improvements

### DIFF
--- a/include/evp_utils.h
+++ b/include/evp_utils.h
@@ -6,6 +6,7 @@
 #ifndef EVP_UTILS_H
 #define EVP_UTILS_H
 
+#include <ec_utils.h>
 #include <openssl/evp.h>
 
 size_t evp_md_ctx_get_digest_size(EVP_MD_CTX *ctx);

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -20,10 +20,8 @@
 #include <limits.h>
 
 #include <bn_utils.h>
-#include <ec_utils.h>
 
 #include <openssl/asn1.h>
-#include <openssl/bn.h>
 #include <openssl/objects.h>
 #include <openssl/ossl_typ.h>
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -17,6 +17,11 @@
 #ifndef HEADER_EC_H
 #define HEADER_EC_H
 
+#include <limits.h>
+
+#include <bn_utils.h>
+#include <ec_utils.h>
+
 #include <openssl/asn1.h>
 #include <openssl/bn.h>
 #include <openssl/objects.h>
@@ -35,7 +40,23 @@ typedef enum {
     POINT_CONVERSION_HYBRID = 6
 } point_conversion_form_t;
 
+/* Abstraction of the EC_GROUP struct */
+struct ec_group_st {
+    int curve_name;
+    point_conversion_form_t asn1_form;
+    BIGNUM *order;
+};
+
 typedef struct ec_group_st EC_GROUP;
+
+/* Abstraction of the EC_KEY struct */
+struct ec_key_st {
+    int references;
+    EC_GROUP *group;
+    point_conversion_form_t conv_form;
+    BIGNUM *priv_key;
+    bool pub_key_is_set;  // We never have to return a public-key object, so just having this flag is enough
+};
 
 EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
 void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);

--- a/include/openssl/md5.h
+++ b/include/openssl/md5.h
@@ -54,4 +54,8 @@ typedef struct MD5state_st {
     unsigned int num;
 } MD5_CTX;
 
+int MD5_Init(MD5_CTX *c);
+int MD5_Final(unsigned char *md, MD5_CTX *c);
+int MD5_Update(MD5_CTX *c, const void *data, size_t len);
+
 #endif

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -98,4 +98,21 @@ typedef struct SHA512state_st {
 } SHA512_CTX;
 #endif
 
+int SHA1_Init(SHA_CTX *c);
+int SHA224_Init(SHA256_CTX *c);
+int SHA256_Init(SHA256_CTX *c);
+int SHA384_Init(SHA512_CTX *c);
+int SHA512_Init(SHA512_CTX *c);
+
+int SHA1_Final(unsigned char *md, SHA_CTX *c);
+int SHA224_Final(unsigned char *md, SHA256_CTX *c);
+int SHA256_Final(unsigned char *md, SHA256_CTX *c);
+int SHA384_Final(unsigned char *md, SHA512_CTX *c);
+int SHA512_Final(unsigned char *md, SHA512_CTX *c);
+
+int SHA1_Update(SHA_CTX *c, const void *data, size_t len);
+int SHA224_Update(SHA256_CTX *c, const void *data, size_t len);
+int SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
+int SHA384_Update(SHA512_CTX *c, const void *data, size_t len);
+int SHA512_Update(SHA512_CTX *c, const void *data, size_t len);
 #endif

--- a/source/bn_override.c
+++ b/source/bn_override.c
@@ -69,8 +69,10 @@ int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
  * and if it was created by BN_new(), also the structure itself.
  */
 void BN_free(BIGNUM *a) {
-    /* Assuming BIGNUMs are always allocated dynamically. */
-    free(a);
+    if (a != NULL) {
+        free(a->d);
+        free(a);
+    }
 }
 
 /*

--- a/source/ec_override.c
+++ b/source/ec_override.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <openssl/ec.h>
+#include <ec_utils.h>
 
 /*
  * Description: In order to construct a builtin curve use the function EC_GROUP_new_by_curve_name and provide the nid of

--- a/source/ec_override.c
+++ b/source/ec_override.c
@@ -186,7 +186,7 @@ int EC_KEY_up_ref(EC_KEY *key) {
 void EC_KEY_free(EC_KEY *key) {
     if (key != NULL &&
         /* We must include this extra guard to avoid spurious arithmetic underflows. */
-        key->references >= 0) {
+        key->references > 0) {
         key->references -= 1;
         if (key->references == 0) {
             EC_GROUP_free(key->group);

--- a/source/ec_override.c
+++ b/source/ec_override.c
@@ -13,22 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <limits.h>
-
-#include <bn_utils.h>
-#include <ec_utils.h>
 #include <openssl/ec.h>
-#include <openssl/objects.h>
-
-#include <proof_helpers/nondet.h>
-#include <proof_helpers/proof_allocators.h>
-
-/* Abstraction of the EC_GROUP struct */
-struct ec_group_st {
-    int curve_name;
-    point_conversion_form_t asn1_form;
-    BIGNUM *order;
-};
 
 /*
  * Description: In order to construct a builtin curve use the function EC_GROUP_new_by_curve_name and provide the nid of
@@ -71,20 +56,11 @@ const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group) {
  * Description: EC_GROUP_free frees the memory associated with the EC_GROUP. If group is NULL nothing is done.
  */
 void EC_GROUP_free(EC_GROUP *group) {
-    if (group) {
+    if (group != NULL) {
         BN_free(group->order);
         free(group);
     }
 }
-
-/* Abstraction of the EC_KEY struct */
-struct ec_key_st {
-    int references;
-    EC_GROUP *group;
-    point_conversion_form_t conv_form;
-    BIGNUM *priv_key;
-    bool pub_key_is_set;  // We never have to return a public-key object, so just having this flag is enough
-};
 
 /*
  * Description: A new EC_KEY with no associated curve can be constructed by calling EC_KEY_new(). The reference count
@@ -208,7 +184,9 @@ int EC_KEY_up_ref(EC_KEY *key) {
  * zero then frees the memory associated with it. If key is NULL nothing is done.
  */
 void EC_KEY_free(EC_KEY *key) {
-    if (key) {
+    if (key != NULL &&
+        /* We must include this extra guard to avoid spurious arithmetic underflows. */
+        key->references >= 0) {
         key->references -= 1;
         if (key->references == 0) {
             EC_GROUP_free(key->group);
@@ -355,9 +333,9 @@ ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len) {
  */
 int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp) {
     assert(ecdsa_sig_is_valid(sig));
-    assert(pp);
-    assert(*pp);                                             // Assuming is never called with *pp == NULL
-    assert(AWS_MEM_IS_WRITABLE(*pp, max_signature_size()));  // *pp has enough space for the signature
+    assert(pp != NULL);
+    assert(*pp != NULL);                                // Assuming is never called with *pp == NULL
+    assert(__CPROVER_w_ok(*pp, max_signature_size()));  // *pp has enough space for the signature
 
     // Documentation says 0 is returned on error, but OpenSSL implementation returns -1
     // To be safe, we return a number <= 0
@@ -484,7 +462,7 @@ size_t max_decryption_size() {
 
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
-    assert(AWS_MEM_IS_WRITABLE(out, len));
+    assert(__CPROVER_w_ok(out, len));
 
     // Currently we ignore the len parameter and just fill the entire buffer with unconstrained data.
     // This is fine because it is strictly more general behavior than writing only len bytes.

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -818,6 +818,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
     // s can be NULL
 
     __CPROVER_havoc_object(md);
+    if (s) *s = EVP_MD_CTX_size(ctx);
     ctx->digest = NULL; /* No additional calls to EVP_DigestUpdate. */
 
     if (nondet_bool()) {
@@ -826,8 +827,6 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
         if (s) *s = garbage;
         return 0;
     }
-
-    if (s) *s = EVP_MD_CTX_size(ctx);
 
     return 1;
 }

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -72,7 +72,7 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
 void EVP_PKEY_free(EVP_PKEY *pkey) {
     if (pkey != NULL &&
         /* We must include this extra guard to avoid spurious arithmetic underflows. */
-        pkey->references >= 0) {
+        pkey->references > 0) {
         pkey->references -= 1;
         if (pkey->references == 0) {
             EC_KEY_free(pkey->ec_key);

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <ec_utils.h>
+#include <evp_utils.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/kdf.h>
@@ -70,7 +70,9 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
  * If key is NULL, nothing is done.
  */
 void EVP_PKEY_free(EVP_PKEY *pkey) {
-    if (pkey) {
+    if (pkey != NULL &&
+        /* We must include this extra guard to avoid spurious arithmetic underflows. */
+        pkey->references >= 0) {
         pkey->references -= 1;
         if (pkey->references == 0) {
             EC_KEY_free(pkey->ec_key);
@@ -173,9 +175,9 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const u
     assert(evp_pkey_ctx_is_valid(ctx));
     assert(ctx->is_initialized_for_signing == true);
     assert(siglen);
-    assert(!sig || (*siglen >= max_signature_size() && AWS_MEM_IS_WRITABLE(sig, *siglen)));
+    assert(!sig || (*siglen >= max_signature_size() && __CPROVER_w_ok(sig, *siglen)));
     assert(tbs);
-    assert(AWS_MEM_IS_READABLE(tbs, tbslen));
+    assert(__CPROVER_r_ok(tbs, tbslen));
 
     if (nondet_bool()) {
         int rv;
@@ -471,12 +473,12 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) {
     assert(IMPLIES(type == EVP_CTRL_GCM_GET_TAG, ctx->encrypt == 1));
     assert(IMPLIES(type == EVP_CTRL_GCM_GET_TAG, ctx->data_processed == true));
     /* Need to be able to write taglen (arg) bytes to buffer ptr. */
-    assert(IMPLIES(type == EVP_CTRL_GCM_GET_TAG, AWS_MEM_IS_WRITABLE(ptr, arg)));
+    assert(IMPLIES(type == EVP_CTRL_GCM_GET_TAG, __CPROVER_w_ok(ptr, arg)));
 
     /* Only legal when decrypting data. */
     assert(IMPLIES(type == EVP_CTRL_GCM_SET_TAG, ctx->encrypt == 0));
     /* Need to be able to write taglen (arg) bytes to buffer ptr. */
-    assert(IMPLIES(type == EVP_CTRL_GCM_SET_TAG, AWS_MEM_IS_WRITABLE(ptr, arg)));
+    assert(IMPLIES(type == EVP_CTRL_GCM_SET_TAG, __CPROVER_w_ok(ptr, arg)));
 
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
@@ -565,14 +567,14 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         ctx->data_remaining = inl - out_size;
     }
     /*
-     * This check is redundant with the following AWS_MEM_IS_WRITABLE.
-     * AWS_MEM_IS_WRITABLE is a macro for __CPROVER_w_ok primitive, which
+     * This check is redundant with the following __CPROVER_w_ok.
+     * __CPROVER_w_ok is a macro for __CPROVER_w_ok primitive, which
      * should return true if out is writable upt to out_size bytes;
-     * however, AWS_MEM_IS_WRITABLE has been replaced by a simple nullness check for now.
+     * however, __CPROVER_w_ok has been replaced by a simple nullness check for now.
      * Thus, we also include an additional check using __CPROVER_OBJECT_SIZE.
      */
     assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
-    assert(AWS_MEM_IS_WRITABLE(out, out_size));
+    assert(__CPROVER_w_ok(out, out_size));
     *outl = out_size;
     return rv;
 }
@@ -603,14 +605,14 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         ctx->data_remaining = inl - out_size;
     }
     /*
-     * This check is redundant with the following AWS_MEM_IS_WRITABLE.
-     * AWS_MEM_IS_WRITABLE is a macro for __CPROVER_w_ok primitive, which
+     * This check is redundant with the following __CPROVER_w_ok.
+     * __CPROVER_w_ok is a macro for __CPROVER_w_ok primitive, which
      * should return true if out is writable upt to out_size bytes;
-     * however, AWS_MEM_IS_WRITABLE has been replaced by a simple nullness check for now.
+     * however, __CPROVER_w_ok has been replaced by a simple nullness check for now.
      * Thus, we also include an additional check using __CPROVER_OBJECT_SIZE.
      */
     assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
-    assert(AWS_MEM_IS_WRITABLE(out, out_size));
+    assert(__CPROVER_w_ok(out, out_size));
     *outl = out_size;
     return rv;
 }
@@ -626,7 +628,7 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl) {
     assert(ctx != NULL);
     if (ctx->padding == true) {
         *outl = ctx->data_remaining;
-        assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
+        assert(__CPROVER_w_ok(out, ctx->data_remaining));
     }
     ctx->data_processed = true;
     int rv;
@@ -644,7 +646,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) {
     assert(ctx != NULL);
     if (ctx->padding == true) {
         *outl = ctx->data_remaining;
-        assert(AWS_MEM_IS_WRITABLE(outm, ctx->data_remaining));
+        assert(__CPROVER_w_ok(outm, ctx->data_remaining));
     }
     ctx->data_processed = true;
     int rv;
@@ -657,16 +659,28 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) {
  * 256, 224, 256, 384 and 512 bits respectively of output from a given input. Return values: These functions return a
  * EVP_MD structure that contains the implementation of the symmetric cipher.
  */
+const EVP_MD *EVP_md5() {
+    static const EVP_MD md = { EVP_MD5, 0, 0, 16 /* Digest length. */, 0, 0, 16 };
+    return &md;
+}
+const EVP_MD *EVP_sha1() {
+    static const EVP_MD md = { EVP_SHA1, 0, 0, 20 /* Digest length. */, 0, 0, 20 };
+    return &md;
+}
+const EVP_MD *EVP_sha224() {
+    static const EVP_MD md = { EVP_SHA224, 0, 0, 28 /* Digest length. */, 0, 0, 28 };
+    return &md;
+}
 const EVP_MD *EVP_sha256() {
-    static const EVP_MD md = { EVP_SHA256, 32 };
+    static const EVP_MD md = { EVP_SHA256, 0, 0, 32 /* Digest length. */, 0, 0, 32 };
     return &md;
 }
 const EVP_MD *EVP_sha384() {
-    static const EVP_MD md = { EVP_SHA384, 48 };
+    static const EVP_MD md = { EVP_SHA384, 0, 0, 48 /* Digest length. */, 0, 0, 48 };
     return &md;
 }
 const EVP_MD *EVP_sha512() {
-    static const EVP_MD md = { EVP_SHA512, 64 };
+    static const EVP_MD md = { EVP_SHA512, 0, 0, 64 /* Digest length. */, 0, 0, 64 };
     return &md;
 }
 
@@ -674,25 +688,41 @@ const EVP_MD *EVP_sha512() {
  * the hash.
  */
 int EVP_MD_size(const EVP_MD *md) {
+    assert(md != NULL);
+    if (md->from == EVP_MD5) {
+        return 16;
+    }
+    if (md->from == EVP_SHA1) {
+        return 20;
+    }
+    if (md->from == EVP_SHA224) {
+        return 28;
+    }
     if (md->from == EVP_SHA256) {
-        return 256;
+        return 32;
     }
     if (md->from == EVP_SHA384) {
-        return 384;
+        return 48;
     }
-    return 512;
+    return 64;
+}
+
+/* Helper function for CBMC proofs: checks if EVP_MD_CTX is valid. */
+bool evp_md_ctx_is_valid(EVP_MD_CTX *ctx) {
+    return ctx && ctx->digest != NULL && ctx->digest->md_size <= EVP_MAX_MD_SIZE &&
+           (ctx->pctx == NULL || evp_pkey_ctx_is_valid(ctx->pctx));
 }
 
 /*
  * Description: Allocates and returns a digest context.
  */
 EVP_MD_CTX *EVP_MD_CTX_new() {
-    EVP_MD_CTX *ctx = malloc(sizeof(EVP_MD_CTX));
+    EVP_MD_CTX *ctx = malloc(sizeof(*ctx));
 
-    if (ctx) {
-        ctx->is_initialized = false;
-        ctx->pkey           = NULL;
-        ctx->digest_size    = 0;
+    if (ctx != NULL) {
+        ctx->digest  = NULL;
+        ctx->md_data = NULL;
+        ctx->pctx    = NULL;
     }
 
     return ctx;
@@ -703,18 +733,33 @@ EVP_MD_CTX *EVP_MD_CTX_new() {
  * the hash. Return values: Returns the digest or block size in bytes.
  */
 int EVP_MD_CTX_size(const EVP_MD_CTX *ctx) {
-    assert(evp_md_ctx_is_valid(ctx));
-    return ctx->digest_size;
+    assert(ctx != NULL);
+    return EVP_MD_size(ctx->digest);
 }
 
 /*
  * Description: Cleans up digest context ctx and frees up the space allocated to it.
  */
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
-    if (ctx) {
-        EVP_PKEY_free(ctx->pkey);
+    if (ctx != NULL) {
+        free(ctx->digest);
+        free(ctx->md_data);
+        EVP_PKEY_CTX_free(ctx->pctx);
         free(ctx);
     }
+}
+
+/*
+ * Description: This call frees resources associated with the context.
+ */
+int EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx) {
+    if (nondet_bool()) return 0;
+    if (ctx != NULL) {
+        free(ctx->digest);
+        free(ctx->md_data);
+        EVP_PKEY_CTX_free(ctx->pctx);
+    }
+    return 1;
 }
 
 /*
@@ -723,17 +768,17 @@ void EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
  * values: Returns 1 for success and 0 for failure.
  */
 int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) {
-    assert(ctx);
-    assert(!ctx->is_initialized);
+    assert(ctx != NULL);  // ctx must be initialized before calling EVP_DigestInit_ex function.
     assert(evp_md_is_valid(type));
-    assert(!impl);  // Assuming that this function is always called in ESDK with impl == NULL
+    assert(impl == NULL);  // Assuming that this function is always called with impl == NULL
 
     if (nondet_bool()) return 0;
 
-    ctx->is_initialized = true;
-    ctx->digest_size    = type->size;
+    ctx->digest  = type;
+    ctx->md_data = malloc(type->md_size);
+    ctx->pctx    = NULL;
 
-    return ctx->is_initialized;
+    return 1;
 }
 
 /*
@@ -749,15 +794,14 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type) {
  * on the same ctx to hash additional data. Return values: Returns 1 for success and 0 for failure.
  */
 int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) {
-    assert(evp_md_ctx_is_valid(ctx));
-    assert(d);
-    assert(AWS_MEM_IS_READABLE(d, cnt));
+    assert(ctx != NULL);
+    assert(ctx->digest != NULL);
+    assert(__CPROVER_r_ok(d, cnt));
 
+    __CPROVER_havoc_object(d);
     if (nondet_bool()) {
-        ctx->is_initialized = false;
         return 0;
     }
-
     return 1;
 }
 
@@ -769,13 +813,12 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) {
  * Return values: Returns 1 for success and 0 for failure.
  */
 int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
-    assert(evp_md_ctx_is_valid(ctx));
-    assert(md);
-    assert(AWS_MEM_IS_WRITABLE(md, ctx->digest_size));
+    assert(ctx != NULL);
+    assert(__CPROVER_w_ok(md, EVP_MD_CTX_size(ctx)));
     // s can be NULL
 
-    write_unconstrained_data(md, ctx->digest_size);
-    ctx->is_initialized = false;
+    __CPROVER_havoc_object(md);
+    ctx->digest = NULL; /* No additional calls to EVP_DigestUpdate. */
 
     if (nondet_bool()) {
         // Something went wrong, can't guarantee *s will have the correct value
@@ -784,7 +827,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
         return 0;
     }
 
-    if (s) *s = ctx->digest_size;
+    if (s) *s = EVP_MD_CTX_size(ctx);
 
     return 1;
 }
@@ -813,8 +856,7 @@ int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
  * failure.
  */
 int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey) {
-    assert(ctx);
-    assert(!ctx->is_initialized);
+    assert(ctx != NULL);
     assert(!pctx);  // Assuming that this function is always called in ESDK with pctx == NULL
     assert(evp_md_is_valid(type));
     assert(!e);  // Assuming that this function is always called in ESDK with e == NULL
@@ -822,10 +864,10 @@ int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *typ
 
     if (nondet_bool()) return 0;
 
-    ctx->is_initialized = true;
+    /*ctx->is_initialized = true;
     ctx->pkey           = pkey;
     pkey->references += 1;
-    ctx->digest_size = type->size;
+    ctx->digest_size = type->size;*/
 
     return 1;
 }
@@ -840,7 +882,7 @@ int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *typ
 int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen) {
     assert(evp_md_ctx_is_valid(ctx));
     assert(sig);
-    assert(AWS_MEM_IS_READABLE(sig, siglen));
+    assert(__CPROVER_r_ok(sig, siglen));
 
     // Since this operation only performs verification, none of the arguments are modified
 
@@ -935,11 +977,11 @@ int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) {
     assert(hmac_ctx_is_valid(ctx));
     assert(ctx->md != NULL);
     int md_size = EVP_MD_size(ctx->md);
-    AWS_MEM_IS_WRITABLE(md, md_size);
+    __CPROVER_w_ok(md, md_size);
     *len = md_size;
     int rv;
     __CPROVER_assume(rv == 1 || rv == 0);
-    __CPROVER_assume(AWS_MEM_IS_READABLE(md, md_size));
+    __CPROVER_assume(__CPROVER_r_ok(md, md_size));
     return rv;
 }
 
@@ -987,14 +1029,9 @@ bool evp_cipher_is_valid(EVP_CIPHER *cipher) {
 }
 
 bool evp_md_is_valid(EVP_MD *md) {
-    return md && ((md->from == EVP_SHA256 && md->size == 32) || (md->from == EVP_SHA384 && md->size == 48) ||
-                  (md->from == EVP_SHA512 && md->size == 64));
-}
-
-/* Helper function for CBMC proofs: checks if EVP_MD_CTX is valid. */
-bool evp_md_ctx_is_valid(EVP_MD_CTX *ctx) {
-    return ctx && ctx->is_initialized && ctx->digest_size <= EVP_MAX_MD_SIZE &&
-           (ctx->pkey == NULL || evp_pkey_is_valid(ctx->pkey));
+    return md && ((md->from == EVP_MD5 && md->md_size == 16) || (md->from == EVP_SHA1 && md->md_size == 20) ||
+                  (md->from == EVP_SHA224 && md->md_size == 28) || (md->from == EVP_SHA256 && md->md_size == 32) ||
+                  (md->from == EVP_SHA384 && md->md_size == 48) || (md->from == EVP_SHA512 && md->md_size == 64));
 }
 
 /* Helper function for CBMC proofs: allocates EVP_MD_CTX nondeterministically. */
@@ -1004,22 +1041,22 @@ EVP_MD_CTX *evp_md_ctx_nondet_alloc() {
 
 /* Helper function for CBMC proofs: checks if EVP_MD_CTX is initialized. */
 bool evp_md_ctx_is_initialized(EVP_MD_CTX *ctx) {
-    return ctx->is_initialized;
+    return (ctx->digest != NULL);
 }
 
 /* Helper function for CBMC proofs: returns digest size. */
 size_t evp_md_ctx_get_digest_size(EVP_MD_CTX *ctx) {
-    return ctx->digest_size;
+    return ctx->digest->ctx_size;
 }
 
 /* Helper function for CBMC proofs: get EVP_PKEY without incrementing the reference count. */
 EVP_PKEY *evp_md_ctx_get0_evp_pkey(EVP_MD_CTX *ctx) {
-    return ctx ? ctx->pkey : NULL;
+    return ctx ? ctx->pctx->pkey : NULL;
 }
 
 /* Helper function for CBMC proofs: set EVP_PKEY without incrementing the reference count. */
 void evp_md_ctx_set0_evp_pkey(EVP_MD_CTX *ctx, EVP_PKEY *pkey) {
-    if (ctx) ctx->pkey = pkey;
+    if (ctx) ctx->pctx->pkey = pkey;
 }
 
 /* Helper function for CBMC proofs: frees the memory of the ctx without freeing the EVP_PKEY. */
@@ -1031,4 +1068,15 @@ void evp_md_ctx_shallow_free(EVP_MD_CTX *ctx) {
 void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags) {
     assert(__CPROVER_w_ok(ctx, sizeof(*ctx)));
     ctx->flags |= flags;
+}
+
+int EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx, int flags) {
+    assert(__CPROVER_w_ok(ctx, sizeof(*ctx)));
+    return (ctx->flags & flags);
+}
+
+int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in) {
+    assert(out != NULL);
+    if (in == NULL) return 0;
+    return (int)nondet_bool();
 }

--- a/source/md5_override.c
+++ b/source/md5_override.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <ec_utils.h>
+#include <openssl/md5.h>
+
+/*
+ * Implemented from RFC1321 The MD5 Message-Digest Algorithm.
+ * Per https://github.com/openssl/openssl/blob/33388b44b67145af2181b1e9528c381c8ea0d1b6/crypto/md5/md5_dgst.c.
+ */
+#define INIT_DATA_A (unsigned long)0x67452301L
+#define INIT_DATA_B (unsigned long)0xefcdab89L
+#define INIT_DATA_C (unsigned long)0x98badcfeL
+#define INIT_DATA_D (unsigned long)0x10325476L
+
+int MD5_Init(MD5_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    *c   = (const MD5_CTX){ 0 }; /* memset(c, 0, sizeof(*c)); */
+    c->A = INIT_DATA_A;
+    c->B = INIT_DATA_B;
+    c->C = INIT_DATA_C;
+    c->D = INIT_DATA_D;
+    return 1;
+}
+
+int MD5_Final(unsigned char *md, MD5_CTX *c) {
+    assert(__CPROVER_w_ok(md, MD5_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const MD5_CTX){ 0 };
+    return 1;
+}
+
+int MD5_Update(MD5_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}

--- a/source/sha_override.c
+++ b/source/sha_override.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <ec_utils.h>
+#include <openssl/sha.h>
+
+#define INIT_DATA_h0 0x67452301UL
+#define INIT_DATA_h1 0xefcdab89UL
+#define INIT_DATA_h2 0x98badcfeUL
+#define INIT_DATA_h3 0x10325476UL
+#define INIT_DATA_h4 0xc3d2e1f0UL
+
+int SHA1_Init(SHA_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    *c    = (const SHA_CTX){ 0 }; /* memset(c, 0, sizeof(*c)); */
+    c->h0 = INIT_DATA_h0;
+    c->h1 = INIT_DATA_h1;
+    c->h2 = INIT_DATA_h2;
+    c->h3 = INIT_DATA_h3;
+    c->h4 = INIT_DATA_h4;
+    return 1;
+}
+
+int SHA224_Init(SHA256_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    *c        = (const SHA256_CTX){ 0 }; /* memset(c, 0, sizeof(*c)); */
+    c->h[0]   = 0xc1059ed8UL;
+    c->h[1]   = 0x367cd507UL;
+    c->h[2]   = 0x3070dd17UL;
+    c->h[3]   = 0xf70e5939UL;
+    c->h[4]   = 0xffc00b31UL;
+    c->h[5]   = 0x68581511UL;
+    c->h[6]   = 0x64f98fa7UL;
+    c->h[7]   = 0xbefa4fa4UL;
+    c->md_len = SHA224_DIGEST_LENGTH;
+    return 1;
+}
+
+int SHA256_Init(SHA256_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    *c        = (const SHA256_CTX){ 0 }; /* memset(c, 0, sizeof(*c)); */
+    c->h[0]   = 0x6a09e667UL;
+    c->h[1]   = 0xbb67ae85UL;
+    c->h[2]   = 0x3c6ef372UL;
+    c->h[3]   = 0xa54ff53aUL;
+    c->h[4]   = 0x510e527fUL;
+    c->h[5]   = 0x9b05688cUL;
+    c->h[6]   = 0x1f83d9abUL;
+    c->h[7]   = 0x5be0cd19UL;
+    c->md_len = SHA256_DIGEST_LENGTH;
+    return 1;
+}
+
+int SHA384_Init(SHA512_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    c->h[0] = U64(0xcbbb9d5dc1059ed8);
+    c->h[1] = U64(0x629a292a367cd507);
+    c->h[2] = U64(0x9159015a3070dd17);
+    c->h[3] = U64(0x152fecd8f70e5939);
+    c->h[4] = U64(0x67332667ffc00b31);
+    c->h[5] = U64(0x8eb44a8768581511);
+    c->h[6] = U64(0xdb0c2e0d64f98fa7);
+    c->h[7] = U64(0x47b5481dbefa4fa4);
+
+    c->Nl     = 0;
+    c->Nh     = 0;
+    c->num    = 0;
+    c->md_len = SHA384_DIGEST_LENGTH;
+    return 1;
+}
+
+int SHA512_Init(SHA512_CTX *c) {
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    c->h[0] = U64(0x6a09e667f3bcc908);
+    c->h[1] = U64(0xbb67ae8584caa73b);
+    c->h[2] = U64(0x3c6ef372fe94f82b);
+    c->h[3] = U64(0xa54ff53a5f1d36f1);
+    c->h[4] = U64(0x510e527fade682d1);
+    c->h[5] = U64(0x9b05688c2b3e6c1f);
+    c->h[6] = U64(0x1f83d9abfb41bd6b);
+    c->h[7] = U64(0x5be0cd19137e2179);
+
+    c->Nl     = 0;
+    c->Nh     = 0;
+    c->num    = 0;
+    c->md_len = SHA512_DIGEST_LENGTH;
+    return 1;
+}
+
+int SHA1_Final(unsigned char *md, SHA_CTX *c) {
+    assert(__CPROVER_w_ok(md, SHA_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const SHA_CTX){ 0 };
+    return 1;
+}
+
+int SHA224_Final(unsigned char *md, SHA256_CTX *c) {
+    assert(__CPROVER_w_ok(md, SHA224_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const SHA256_CTX){ 0 };
+    return 1;
+}
+
+int SHA256_Final(unsigned char *md, SHA256_CTX *c) {
+    assert(__CPROVER_w_ok(md, SHA256_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const SHA256_CTX){ 0 };
+    return 1;
+}
+
+int SHA384_Final(unsigned char *md, SHA512_CTX *c) {
+    assert(__CPROVER_w_ok(md, SHA384_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const SHA512_CTX){ 0 };
+    return 1;
+}
+
+int SHA512_Final(unsigned char *md, SHA512_CTX *c) {
+    assert(__CPROVER_w_ok(md, SHA512_DIGEST_LENGTH));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    __CPROVER_havoc_object(md);
+    *c = (const SHA512_CTX){ 0 };
+    return 1;
+}
+
+int SHA1_Update(SHA_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}
+
+int SHA224_Update(SHA256_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}
+
+int SHA256_Update(SHA256_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}
+
+int SHA384_Update(SHA512_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}
+
+int SHA512_Update(SHA512_CTX *c, const void *data, size_t len) {
+    assert(__CPROVER_w_ok(data, len));
+    assert(c != NULL);
+    if (nondet_bool()) return 0;
+    return 1;
+}

--- a/source/sha_override.c
+++ b/source/sha_override.c
@@ -16,6 +16,10 @@
 #include <ec_utils.h>
 #include <openssl/sha.h>
 
+/*
+ * All macros extracted from the original openssl implementation.
+ * Per https://github.com/openssl/openssl/blob/e39e295e205ab8461d3ac814129bbb08c2d1266d/crypto/sha/sha_local.h.
+ */
 #define INIT_DATA_h0 0x67452301UL
 #define INIT_DATA_h1 0xefcdab89UL
 #define INIT_DATA_h2 0x98badcfeUL


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

The following changes are necessary for the new set of `s2n_hash` proofs:
- `BN_free` must not assume `BIGNUM`s are always allocated;
- Updates EC model to avoid spurious arithmetic underflows;
- Improves EVP model assumptions;
- Adds MD5 model;
- Adds a SHA model;
- Replaces all instances of `AWS_MEM_IS_WRITABLE` and `AWS_MEM_IS_READABLE` with `__CPROVER_w_ok` and `__CPROVER_r_ok`, respectively. The macros are not part of this codebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
