### PR TITLE
Preconditions must consider when length is zero

### DIFF
--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -804,7 +804,7 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type) {
 int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) {
     assert(ctx != NULL);
     assert(ctx->digest != NULL);
-    assert(__CPROVER_r_ok(d, cnt));
+    assert(cnt == 0 || __CPROVER_r_ok(d, cnt));
 
     __CPROVER_havoc_object(d);
     if (nondet_bool()) {

--- a/source/md5_override.c
+++ b/source/md5_override.c
@@ -46,7 +46,7 @@ int MD5_Final(unsigned char *md, MD5_CTX *c) {
 }
 
 int MD5_Update(MD5_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;

--- a/source/sha_override.c
+++ b/source/sha_override.c
@@ -154,35 +154,35 @@ int SHA512_Final(unsigned char *md, SHA512_CTX *c) {
 }
 
 int SHA1_Update(SHA_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;
 }
 
 int SHA224_Update(SHA256_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;
 }
 
 int SHA256_Update(SHA256_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;
 }
 
 int SHA384_Update(SHA512_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;
 }
 
 int SHA512_Update(SHA512_CTX *c, const void *data, size_t len) {
-    assert(__CPROVER_w_ok(data, len));
+    assert(len == 0 || __CPROVER_w_ok(data, len));
     assert(c != NULL);
     if (nondet_bool()) return 0;
     return 1;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*

N/A.

*Description of changes:*

Update preconditions on `*Update` functions to consider when length is zero. Before, they were to restrictive. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
