### PR TITLE
Avoid __CPROVER_havoc_object in EVP model

### DIFF
--- a/include/ec_utils.h
+++ b/include/ec_utils.h
@@ -46,4 +46,6 @@ size_t max_signature_size();
 
 void write_unconstrained_data(unsigned char *out, size_t len);
 
+unsigned char nondet_unsigned_char();
+
 #endif

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -825,7 +825,9 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
     assert(__CPROVER_w_ok(md, EVP_MD_CTX_size(ctx)));
     // s can be NULL
 
-    __CPROVER_havoc_object(md);
+    unsigned char havoc_md;
+    *md = havoc_md;
+
     if (s) *s = EVP_MD_CTX_size(ctx);
     ctx->digest = NULL; /* No additional calls to EVP_DigestUpdate. */
 

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -825,8 +825,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
     assert(__CPROVER_w_ok(md, EVP_MD_CTX_size(ctx)));
     // s can be NULL
 
-    unsigned char havoc_md;
-    *md = havoc_md;
+    *md = nondet_unsigned_char();
 
     if (s) *s = EVP_MD_CTX_size(ctx);
     ctx->digest = NULL; /* No additional calls to EVP_DigestUpdate. */


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*

N/A.

*Description of changes:*

If `md` comes from the same object as `ctx` or it's even part of a bigger struct, all object will be havocked when using `__CPROVER_havoc_object`. In this case, we don't want that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
