### PR TITLE
Removes CPROVER primitives from assumptions

### DIFF
--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -989,7 +989,11 @@ int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) {
     *len = md_size;
     int rv;
     __CPROVER_assume(rv == 1 || rv == 0);
-    __CPROVER_assume(__CPROVER_r_ok(md, md_size));
+    /*
+     * Using __CPROVER_r_ok(md, md_size)  would make this assumption stronger,
+     * but the use of these primitives in assumptions may lead to spurious results.
+     */
+    __CPROVER_assume(md != NULL);
     return rv;
 }
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
Removes CPROVER primitives from assumptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
