### PR TITLE
Adds missing includes to `hmac.h` file

### DIFF
--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -17,6 +17,10 @@
 #ifndef HEADER_HMAC_H
 #define HEADER_HMAC_H
 
+#include "ossl_typ.h"
+
+#include <stdbool.h>
+
 struct hmac_ctx_st {
     const EVP_MD *md;
     EVP_MD_CTX *md_ctx;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
Adds missing includes to `hmac.h` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
