### PR TITLE
Added support for EVP_CIPHER_CTX

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -26,7 +26,7 @@
 #define EVP_PKEY_HKDF 1036                    /* Reference from obj_mac.h. */
 #define EVP_MD_CTX_FLAG_NON_FIPS_ALLOW 0x0008 /* Allow use of non FIPS digest in FIPS mode. */
 
-enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM };
+enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM, EVP_AES_128_ECB };
 enum evp_sha { EVP_MD5, EVP_SHA1, EVP_SHA224, EVP_SHA256, EVP_SHA384, EVP_SHA512 };
 
 // An EVP_AEAD_CTX represents an AEAD algorithm configured with a specific key
@@ -63,6 +63,7 @@ struct evp_cipher_ctx_st {
     int encrypt;
     int iv_len;           // default: DEFAULT_IV_LEN.
     bool iv_set;          // boolean marks if iv has been set. Default:false.
+    int key_len;          // default: DEFAULT_KEY_LEN
     bool padding;         // boolean marks if padding is enabled. Default:true.
     bool data_processed;  // boolean marks if has encrypt/decrypt final has been called. Default:false.
     int data_remaining;   // how much is left to be encrypted/decrypted. Default: 0.
@@ -131,6 +132,9 @@ int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
 int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
 
+#define EVP_CIPHER_CTX_key_length(ctx) ((ctx)->key_len)
+
+void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *ctx);
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
 int EVP_CipherInit_ex(
     EVP_CIPHER_CTX *ctx,
@@ -156,6 +160,7 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out, const unsigned char *in,
 const EVP_CIPHER *EVP_aes_128_gcm(void);
 const EVP_CIPHER *EVP_aes_192_gcm(void);
 const EVP_CIPHER *EVP_aes_256_gcm(void);
+const EVP_CIPHER *EVP_aes_128_ecb(void);
 
 const EVP_MD *EVP_md5(void);
 const EVP_MD *EVP_sha1(void);

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -1052,8 +1052,9 @@ bool evp_pkey_ctx_is_valid(EVP_PKEY_CTX *ctx) {
 }
 
 bool evp_cipher_is_valid(EVP_CIPHER *cipher) {
-    return cipher &&
-           (cipher->from == EVP_AES_128_GCM || cipher->from == EVP_AES_192_GCM || cipher->from == EVP_AES_256_GCM || cipher->from == EVP_AES_128_ECB);
+    return cipher && (cipher->from == EVP_AES_128_GCM || cipher->from == EVP_AES_192_GCM ||
+                      cipher->from == EVP_AES_256_GCM || cipher->from == EVP_AES_128_ECB)
+        :
 }
 
 bool evp_md_is_valid(EVP_MD *md) {

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -19,7 +19,7 @@
 #include <openssl/kdf.h>
 #include <openssl/rsa.h>
 
-#define DEFAULT_IV_LEN 12       // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
+#define DEFAULT_IV_LEN 12  // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
 #define DEFAULT_KEY_LEN 32
 #define DEFAULT_BLOCK_SIZE 128  // For GCM AES, the default block size is 128
 

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -20,6 +20,7 @@
 #include <openssl/rsa.h>
 
 #define DEFAULT_IV_LEN 12       // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
+#define DEFAULT_KEY_LEN 32
 #define DEFAULT_BLOCK_SIZE 128  // For GCM AES, the default block size is 128
 
 /*
@@ -416,6 +417,17 @@ const EVP_CIPHER *EVP_aes_256_gcm(void) {
     static const EVP_CIPHER cipher = { EVP_AES_256_GCM, 128 };
     return &cipher;
 }
+const EVP_CIPHER *EVP_aes_128_ecb(void) {
+    static const EVP_CIPHER cipher = { EVP_AES_128_ECB, 128 };
+    return &cipher;
+}
+
+/* From MAN pages: EVP_CIPHER_CTX_init() initializes cipher contex
+ * ctx. */
+/* It's not entirely clear what this function is intended to do. */
+void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *ctx) {
+    return;
+}
 
 /*
  * EVP_CIPHER_CTX_new() creates a cipher context.
@@ -425,6 +437,7 @@ EVP_CIPHER_CTX *EVP_CIPHER_CTX_new() {
     if (cipher_ctx) {
         cipher_ctx->iv_len         = DEFAULT_IV_LEN;
         cipher_ctx->iv_set         = false;
+        cipher_ctx->key_len        = DEFAULT_KEY_LEN;
         cipher_ctx->padding        = true;
         cipher_ctx->data_processed = false;
         cipher_ctx->data_remaining = 0;
@@ -511,7 +524,6 @@ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx) {
 int EVP_EncryptInit_ex(
     EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv) {
     assert(ctx != NULL);
-    assert(type != NULL);
     ctx->encrypt = 1;
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
@@ -1041,7 +1053,7 @@ bool evp_pkey_ctx_is_valid(EVP_PKEY_CTX *ctx) {
 
 bool evp_cipher_is_valid(EVP_CIPHER *cipher) {
     return cipher &&
-           (cipher->from == EVP_AES_128_GCM || cipher->from == EVP_AES_192_GCM || cipher->from == EVP_AES_256_GCM);
+           (cipher->from == EVP_AES_128_GCM || cipher->from == EVP_AES_192_GCM || cipher->from == EVP_AES_256_GCM || cipher->from == EVP_AES_128_ECB);
 }
 
 bool evp_md_is_valid(EVP_MD *md) {


### PR DESCRIPTION
Added EVP_CIPHER_CTX key_len, EVP_aes_128_ecb, EVP_CIPHER_CTX_init

Let me know if any of this needs to be changed.  One assertion was removed from EVP_EncryptInit_ex based on usage in other projects.