### PR TITLE
Add X509_CRL openssl stub

### DIFF
--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -17,6 +17,10 @@ typedef struct x509_st {
     /* See https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in */
 } X509;
 
+typedef struct x509_crl_st {
+    /* See https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in */
+} X509_CRL;
+
 typedef struct x509_object_st {
     /* See https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in */
 } X509_OBJECT;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
A recent [PR to s2n-tls](https://github.com/aws/s2n-tls/pull/3501) makes use of X509_CRL in a header: 

https://github.com/aws/s2n-tls/blob/8525a9bbae15574ec6b90b46b4c58f4637e84978/tls/s2n_x509_validator.h#L63

This causes the CBMC build to fail: 

https://d35jgt3rzs4wwu.cloudfront.net/final/e9be81ca-ef15-4749-bb28-66a7895a1633/pipelines/s2n_add_overflow/index.html#job-8576834f-2aef-476f-a6f4-18c64b602cc3

This PR adds a X509_CRL struct to openssl/x509.h to fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
