### PR TITLE
Match documented signature of X509_STORE_CTX_get1_chain

### DIFF
--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -35,9 +35,9 @@ typedef struct x509_store_ctx_st {
 
 int i2d_X509(X509 *x, unsigned char **out);
 void X509_free(X509 *a);
-struct stack_st_X509 *X509_STORE_CTX_get1_chain(const X509_STORE_CTX *ctx);
+STACK_OF(X509) * X509_STORE_CTX_get1_chain(const X509_STORE_CTX *ctx);
 // the following are actually macros in the original implementation
-int sk_X509_num(const struct stack_st_X509 *);
-void *sk_X509_value(const struct stack_st_X509 *, int);
+int sk_X509_num(const STACK_OF(X509) *);
+void *sk_X509_value(const STACK_OF(X509) *, int);
 
 #endif

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -11,7 +11,7 @@
 #define X509_H
 /* x509 */
 
-#define STACK_OF(type) type
+#define STACK_OF(type) struct stack_st_##type
 
 typedef struct x509_st {
     /* See https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/s2n-tls/issues/4246

*Description of changes:*
The [documented signature](https://www.openssl.org/docs/man1.1.1/man3/X509_STORE_CTX_get1_chain.html) of X509_STORE_CTX_get1_chain is:
```
 STACK_OF(X509) *X509_STORE_CTX_get1_chain(X509_STORE_CTX *ctx);
```
While `STACK_OF(X509)` would normally be equivalent to `struct stack_st_X509`, this header also [redefines](https://github.com/lrstewart/aws-verification-model-for-libcrypto/blob/main/include/openssl/x509.h#L14) the `STACK_OF(type)` macro to just be equivalent to `type`. So s2n-tls sees "Incompatible pointer types" warnings when it does something like `STACK_OF(X509) *result = X509_STORE_CTX_get1_chain(ctx)`.

But this change could just transfer the warning to anyone who uses stack_st_X509 directly instead of STACK_OF(X509), so maybe you guys want to fix this a different way. I considered properly defining STACK_OF(type) as `struct stack_st_##type`, and that also compiled for me with no errors, but I suspect you might have chosen not to do that on purpose to keep definitions simple.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
