### PR TITLE
Fix STACK_OF(type) definition

### DIFF
--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -11,7 +11,7 @@
 #define X509_H
 /* x509 */
 
-#define STACK_OF(type) struct stack_st_##type
+#define STACK_OF(type) type
 
 typedef struct x509_st {
     /* See https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/s2n-tls/issues/4246

*Description of changes:*

#43 partially solved the linked issue, but also introduced a new error by defining 
`#define STACK_OF(type) struct stack_st_##type`

Since `STACK_OF()` macro only provides forward definition of `struct stack_st_X509`, this makes an incomplete type. 
Therefore when running CBMC proof build, it is detected as an incomplete type and throws conversion errors when doing something like this (`cert_chain_from_wire` is defined using `STACK_OF(X509)` here):
```
s2n_x509_validator->cert_chain_from_wire = malloc(sizeof(*(s2n_x509_validator->cert_chain_from_wire)));
```
This change simplifies the definition from `#define STACK_OF(type) struct stack_st_##type` to `#define STACK_OF(type) struct type`.

Alternatively, explicitly defining the stack_st_X509 struct also solved the error if you prefer to keep the current definition of `STACK_OF` macro

```
typedef struct stack_st_X509 {
    /* minimal definition */
} STACK_OF_X509;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
