### PR TITLE
feat: add EVP_MD_fetch

### DIFF
--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -91,6 +91,7 @@ typedef struct evp_pkey_st EVP_PKEY;
 
 typedef struct engine_st ENGINE;
 typedef struct rand_meth_st RAND_METHOD;
+typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
 
 #define ASN1_GENERALIZEDTIME ASN1_STRING
 

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -722,7 +722,7 @@ EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm, const char *prope
     } else if (strcmp(algorithm, "SHA256") == 0) {
         md_value = EVP_sha256();
     } else if (strcmp(algorithm, "SHA384") == 0) {
-        md_value = EVP_sha256();
+        md_value = EVP_sha384();
     } else if (strcmp(algorithm, "SHA512") == 0) {
         md_value = EVP_sha512();
     }

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -706,6 +706,35 @@ const EVP_MD *EVP_sha512() {
     return &md;
 }
 
+EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm, const char *properties) {
+    // Assume this method is always called without a library context
+    assert(ctx != NULL);
+
+    // Reuse the old initialization values to set value
+    EVP_MD *md_value = NULL;
+    if (algorithm == "MD5") {
+        md_value = EVP_md5();
+    } else if (algorithm == "SHA1") {
+        md_value = EVP_sha1();
+    } else if (algorithm == "SHA224") {
+        md_value = EVP_sha224();
+    } else if (algorithm == "SHA256") {
+        md_value = EVP_sha256();
+    } else if (algorithm == "SHA384") {
+        md_value = EVP_sha256();
+    } else if (algorithm == "SHA512") {
+        md_value = EVP_sha512();
+    }
+
+    if (md_value) {
+        EVP_MD *md = malloc(sizeof(EVP_MD));
+        *md        = *md_value;
+        return md;
+    } else {
+        return NULL;
+    }
+}
+
 /* Description: Return the size of the message digest when passed an EVP_MD or an EVP_MD_CTX structure, i.e. the size of
  * the hash.
  */

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -19,6 +19,7 @@
 #include <openssl/kdf.h>
 #include <openssl/rsa.h>
 
+#include <string.h>
 #include <assert.h>
 
 #define DEFAULT_IV_LEN 12  // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
@@ -712,17 +713,17 @@ EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm, const char *prope
 
     // Reuse the old initialization values to set value
     EVP_MD *md_value = NULL;
-    if (algorithm == "MD5") {
+    if (strcmp(algorithm, "MD5") == 0) {
         md_value = EVP_md5();
-    } else if (algorithm == "SHA1") {
+    } else if (strcmp(algorithm, "SHA1") == 0) {
         md_value = EVP_sha1();
-    } else if (algorithm == "SHA224") {
+    } else if (strcmp(algorithm, "SHA224") == 0) {
         md_value = EVP_sha224();
-    } else if (algorithm == "SHA256") {
+    } else if (strcmp(algorithm, "SHA256") == 0) {
         md_value = EVP_sha256();
-    } else if (algorithm == "SHA384") {
+    } else if (strcmp(algorithm, "SHA384") == 0) {
         md_value = EVP_sha256();
-    } else if (algorithm == "SHA512") {
+    } else if (strcmp(algorithm, "SHA512") == 0) {
         md_value = EVP_sha512();
     }
 

--- a/source/evp_override.c
+++ b/source/evp_override.c
@@ -19,8 +19,8 @@
 #include <openssl/kdf.h>
 #include <openssl/rsa.h>
 
-#include <string.h>
 #include <assert.h>
+#include <string.h>
 
 #define DEFAULT_IV_LEN 12  // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
 #define DEFAULT_KEY_LEN 32


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
s2n-tls needs to call the new openssl3 method EVP_MD_fetch, so this adds it to the model.

**Should this method non-deterministically return NULL?** I considered this since openssl3 providers might not support even common algorithms like SHA256. But the existing model already assumes EVP_sha256() never returns NULL, and in openssl3 EVP_sha256() is just a wrapper around EVP_MD_fetch(). Also, the rest of the model methods do `assert(md != NULL)` rather than returning an error signal when md == NULL, which causes problems if we start unpredictably returning NULLs for mds all over the place. Just making EVP_MD_fetch() a wrapper around the existing EVP md methods seems like the simplest solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
