### PR TITLE
Add definition for ASN1_OBJECT

### DIFF
--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -69,6 +69,17 @@ typedef int ASN1_BOOLEAN;
 typedef int ASN1_NULL;
 #endif
 
+/* From https://github.com/openssl/openssl/blob/master/include/crypto/asn1.h */
+struct asn1_object_st {
+    const char *sn, *ln;
+    int nid;
+    int length;
+    const unsigned char *data;
+    int flags;
+};
+
+typedef struct asn1_object_st ASN1_OBJECT;
+
 #ifdef BIGNUM
 #    undef BIGNUM
 #endif


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

https://github.com/aws/s2n-tls/pull/5321 requires a libcrypto `ASN1_OBJECT` to be defined in a header which is imported by CBMC. [This caused our CBMC tests to fail](https://github.com/aws/s2n-tls/actions/runs/15152314716/job/42600539860#step:15:1126), since `ASN1_OBJECT` isn't defined:
```
/usr/libexec/litani/litani exec --command ...

/home/runner/work/s2n-tls/s2n-tls/tls/s2n_config.h:175:1: error: syntax error before 'ASN1_OBJECT'

     STACK_OF(ASN1_OBJECT) *custom_crit_oids;

PARSING ERROR
```

This PR adds the definition for `ASN1_OBJECT`, similar to the existing `asn1_string_st` definitions.

*Testing:*

I added an `ASN1_OBJECT` definition to the relevant header file in s2n-tls in https://github.com/aws/s2n-tls/pull/5324, and pointed the aws-verification-model-for-libcrypto submodule to this branch on my fork, which [allowed the CBMC tests to succeed](https://github.com/aws/s2n-tls/actions/runs/15171423511/job/42662169409?pr=5324).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
